### PR TITLE
feat: use pointer-lock

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,14 +8,49 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
     <title>evenstone</title>
+    <style>
+      :root {
+        --evenstone-cursor-size: 24px;
+      }
+      html,
+      body,
+      *,
+      *::before,
+      *::after {
+        cursor: none !important;
+      }
+      #cursor-hit-area {
+        position: fixed;
+        inset: 0;
+        z-index: 900;
+        background: transparent;
+        cursor: none !important;
+      }
+      #custom-cursor {
+        position: fixed;
+        left: 0;
+        top: 0;
+        z-index: 1000;
+        width: var(--evenstone-cursor-size);
+        height: var(--evenstone-cursor-size);
+        border: 1px solid rgba(244, 240, 232, 0.92);
+        border-radius: 50%;
+        pointer-events: none;
+        transform: translate3d(-100px, -100px, 0);
+      }
+    </style>
+    <script>
+      document.documentElement.classList.add("using-custom-cursor");
+    </script>
   </head>
   <body>
     <canvas id="halo"></canvas>
     <div class="top-glow"></div>
 
     <div id="title-card" class="title-card">evenstone</div>
-
-    <button id="about" class="link">about</button>
+    <span id="about" class="link" role="button" tabindex="0">about</span>
+    <div id="cursor-hit-area" aria-hidden="true"></div>
+    <div id="custom-cursor" aria-hidden="true"></div>
 
     <main class="layout">
       <div class="stage-stack">

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,8 +13,10 @@ const HALO_MAX_DIM = 96; // halo internal resolution; sigma≈5 blur → soft gl
 const stageCanvas = document.getElementById("stage") as HTMLCanvasElement;
 const haloCanvas = document.getElementById("halo") as HTMLCanvasElement;
 const timestampEl = document.getElementById("timestamp") as HTMLElement;
-const aboutBtn = document.getElementById("about") as HTMLButtonElement;
+const aboutBtn = document.getElementById("about") as HTMLElement;
 const aboutModal = document.getElementById("about-modal") as HTMLElement;
+const cursorHitArea = document.getElementById("cursor-hit-area") as HTMLElement;
+const customCursor = document.getElementById("custom-cursor") as HTMLElement;
 
 const stageScene = new Scene(createGl(stageCanvas));
 const halo = new Halo(createGl(haloCanvas), HALO_MAX_DIM, HALO_MAX_DIM);
@@ -22,12 +24,14 @@ const halo = new Halo(createGl(haloCanvas), HALO_MAX_DIM, HALO_MAX_DIM);
 charFlicker("about", 6000);
 
 let aboutOpen = false;
+let lastActivation = -Infinity;
 
 function openAbout(): void {
   if (aboutOpen) return;
   aboutOpen = true;
   aboutModal.classList.add("open");
   aboutModal.setAttribute("aria-hidden", "false");
+  aboutBtn.classList.remove("hover");
 }
 
 function closeAbout(): void {
@@ -37,31 +41,216 @@ function closeAbout(): void {
   aboutModal.setAttribute("aria-hidden", "true");
 }
 
-// preventDefault on mousedown stops the about button from getting focused
-// on click. Focus is the trigger for Chrome's cursor reset glitch — without
-// focus moving to the button, the cursor URL stays applied throughout.
+function toggleAbout(): void {
+  if (aboutOpen) closeAbout();
+  else openAbout();
+}
+
+function hitsAbout(x: number, y: number): boolean {
+  const rect = aboutBtn.getBoundingClientRect();
+  return x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom;
+}
+
+function isMouseLikePointer(e: PointerEvent): boolean {
+  return e.pointerType === "mouse" || e.pointerType === "pen";
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
 aboutBtn.addEventListener("mousedown", (e) => e.preventDefault());
 
 aboutBtn.addEventListener("click", (e) => {
   e.stopPropagation();
-  if (aboutOpen) closeAbout();
-  else openAbout();
+  toggleAbout();
+});
+
+aboutBtn.addEventListener("keydown", (e) => {
+  if (e.key !== "Enter" && e.key !== " ") return;
+  e.preventDefault();
+  e.stopPropagation();
+  toggleAbout();
 });
 
 // Click anywhere on the modal backdrop or its content closes it.
 aboutModal.addEventListener("click", () => closeAbout());
 
-// Custom cursor: a small DOM ring that follows the mouse. The system
-// cursor is hidden via CSS — if Chrome leaks the system cursor on certain
-// transitions, the cursor URL fallback (a transparent PNG) holds the line.
 function setupCursor(): void {
-  if (!matchMedia("(hover: hover) and (pointer: fine)").matches) return;
-  const el = document.createElement("div");
-  el.className = "cursor";
-  document.body.appendChild(el);
-  document.addEventListener("mousemove", (e) => {
-    el.style.transform = `translate(${e.clientX}px, ${e.clientY}px) translate(-50%, -50%)`;
+  document.documentElement.classList.add("using-custom-cursor");
+  document.documentElement.style.setProperty("cursor", "none", "important");
+  document.body.style.setProperty("cursor", "none", "important");
+  cursorHitArea.style.setProperty("cursor", "none", "important");
+
+  let virtualCursorX = window.innerWidth / 2;
+  let virtualCursorY = window.innerHeight / 2;
+  let pointerLockPending = false;
+  let suppressFollowUpClick = false;
+  let suppressFollowUpClickTimer: number | null = null;
+
+  const isPointerLocked = () => document.pointerLockElement === cursorHitArea;
+
+  const updateAboutHover = (x: number, y: number) => {
+    aboutBtn.classList.toggle("hover", !aboutOpen && hitsAbout(x, y));
+  };
+
+  const positionCursor = (x: number, y: number) => {
+    virtualCursorX = clamp(x, 0, window.innerWidth);
+    virtualCursorY = clamp(y, 0, window.innerHeight);
+    customCursor.style.transform = `translate3d(${Math.round(
+      virtualCursorX - 12
+    )}px, ${Math.round(virtualCursorY - 12)}px, 0)`;
+    updateAboutHover(virtualCursorX, virtualCursorY);
+  };
+
+  const requestCursorLock = () => {
+    if (isPointerLocked() || pointerLockPending) return;
+    pointerLockPending = true;
+    try {
+      const result = cursorHitArea.requestPointerLock();
+      if (result && typeof result.catch === "function") {
+        void result
+          .catch(() => {
+            // Chrome owns pointer-lock permission and escape UI; rejection only
+            // means we stay in the CSS-hidden fallback until the next gesture.
+          })
+          .finally(() => {
+            pointerLockPending = false;
+          });
+      } else {
+        pointerLockPending = false;
+      }
+    } catch {
+      pointerLockPending = false;
+    }
+  };
+
+  const markPointerActivationHandled = () => {
+    suppressFollowUpClick = true;
+    if (suppressFollowUpClickTimer !== null) {
+      clearTimeout(suppressFollowUpClickTimer);
+    }
+    suppressFollowUpClickTimer = window.setTimeout(() => {
+      suppressFollowUpClick = false;
+      suppressFollowUpClickTimer = null;
+    }, 1000);
+  };
+
+  const consumeFollowUpClick = () => {
+    if (!suppressFollowUpClick) return false;
+    suppressFollowUpClick = false;
+    if (suppressFollowUpClickTimer !== null) {
+      clearTimeout(suppressFollowUpClickTimer);
+      suppressFollowUpClickTimer = null;
+    }
+    return true;
+  };
+
+  positionCursor(virtualCursorX, virtualCursorY);
+
+  cursorHitArea.addEventListener("pointermove", (e) => {
+    if (!isMouseLikePointer(e)) return;
+    if (!isPointerLocked()) {
+      positionCursor(e.clientX, e.clientY);
+    }
   });
+
+  cursorHitArea.addEventListener("mousemove", (e) => {
+    if (!isPointerLocked()) {
+      positionCursor(e.clientX, e.clientY);
+    }
+  });
+
+  cursorHitArea.addEventListener("pointerleave", () => {
+    if (!isPointerLocked()) {
+      aboutBtn.classList.remove("hover");
+    }
+  });
+
+  const activateAt = (x: number, y: number, timeStamp: number) => {
+    lastActivation = timeStamp;
+    updateAboutHover(x, y);
+
+    if (aboutOpen) {
+      closeAbout();
+      return;
+    }
+
+    if (hitsAbout(x, y)) {
+      openAbout();
+    }
+  };
+
+  cursorHitArea.addEventListener("pointerdown", (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!isMouseLikePointer(e)) {
+      return;
+    }
+    if (!isPointerLocked()) {
+      positionCursor(e.clientX, e.clientY);
+    }
+    requestCursorLock();
+    markPointerActivationHandled();
+    activateAt(virtualCursorX, virtualCursorY, e.timeStamp);
+  });
+
+  cursorHitArea.addEventListener("mousedown", (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!isPointerLocked()) {
+      positionCursor(e.clientX, e.clientY);
+    }
+    requestCursorLock();
+    if (e.timeStamp - lastActivation > 100) {
+      markPointerActivationHandled();
+      activateAt(virtualCursorX, virtualCursorY, e.timeStamp);
+    }
+  });
+
+  cursorHitArea.addEventListener("click", (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    requestCursorLock();
+    if (!consumeFollowUpClick() && e.timeStamp - lastActivation > 1000) {
+      activateAt(virtualCursorX, virtualCursorY, e.timeStamp);
+    }
+  });
+
+  document.addEventListener(
+    "mousemove",
+    (e) => {
+      if (!isPointerLocked()) return;
+      e.preventDefault();
+      e.stopPropagation();
+      positionCursor(virtualCursorX + e.movementX, virtualCursorY + e.movementY);
+    },
+    true
+  );
+
+  document.addEventListener("pointerlockchange", () => {
+    pointerLockPending = false;
+    document.documentElement.classList.toggle(
+      "pointer-lock-active",
+      isPointerLocked()
+    );
+    updateAboutHover(virtualCursorX, virtualCursorY);
+  });
+
+  document.addEventListener("pointerlockerror", () => {
+    pointerLockPending = false;
+  });
+
+  window.addEventListener("resize", () => {
+    positionCursor(virtualCursorX, virtualCursorY);
+  });
+
+  for (const eventName of ["pointerup", "mouseup"]) {
+    cursorHitArea.addEventListener(eventName, (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+    });
+  }
 }
 setupCursor();
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -20,6 +20,7 @@
   --text: #f4f0e8;
   --mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
   --serif: "Iowan Old Style", "Iowan Old Style BT", Georgia, serif;
+  --evenstone-cursor-size: 24px;
 
   /* Top fog tint — set in JS to the current photo's sky color, transitions
    * smoothly during photo crossfades. @property below makes the color
@@ -32,6 +33,19 @@
   syntax: "<color>";
   inherits: true;
   initial-value: rgba(220, 220, 220, 0);
+}
+
+html,
+body,
+*,
+*::before,
+*::after {
+  cursor: none !important;
+}
+
+*:focus,
+*:focus-visible {
+  outline: none !important;
 }
 
 html {
@@ -199,11 +213,11 @@ body::after {
   padding: 6px 4px;
   transition: opacity 0.3s ease;
 }
-.link:hover {
+.link:hover,
+.link.hover {
   opacity: 1;
 }
 .link.disabled {
-  pointer-events: none;
   opacity: 0.3;
 }
 
@@ -300,7 +314,7 @@ body::after {
 .about-modal {
   position: fixed;
   inset: 0;
-  z-index: 10;
+  z-index: 40;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -392,41 +406,51 @@ body::after {
   animation: fadeout 2s forwards;
 }
 
-/* Custom cursor — a small DOM ring that follows the mouse. The system
- * cursor is hidden two ways at once:
- *   1. `cursor: none` on every element
- *   2. A transparent 1×1 PNG as a cursor URL fallback — when Chrome
- *      briefly forgets `cursor: none` on click events (a real Chrome
- *      quirk), it still has a valid cursor (just invisible) instead of
- *      reverting to the system arrow. */
-.cursor {
-  display: none;
+/* A permanent transparent hit layer owns mouse input, while pointer lock
+ * turns mouse motion into deltas for the custom cursor below.
+ */
+#cursor-hit-area {
   position: fixed;
-  top: 0;
-  left: 0;
-  width: 12px;
-  height: 12px;
-  border: 1px solid rgba(244, 240, 232, 0.9);
-  border-radius: 50%;
-  pointer-events: none;
-  z-index: 1000;
+  inset: 0;
+  z-index: 900;
+  background: transparent;
+  pointer-events: auto;
+  user-select: none;
+  -webkit-user-select: none;
+  touch-action: none;
+  -webkit-tap-highlight-color: transparent;
+  cursor: none !important;
 }
 
-@media (hover: hover) and (pointer: fine) {
-  *,
-  *::before,
-  *::after {
-    cursor: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP4//8/AwAI/AL+XJrk9AAAAABJRU5ErkJggg==")
-        0 0,
-      none !important;
-  }
-  *:focus,
-  *:focus-visible {
-    outline: none !important;
-  }
-  .cursor {
-    display: block;
-  }
+#custom-cursor {
+  position: fixed;
+  left: 0;
+  top: 0;
+  z-index: 1000;
+  width: var(--evenstone-cursor-size);
+  height: var(--evenstone-cursor-size);
+  border: 1px solid rgba(244, 240, 232, 0.92);
+  border-radius: 50%;
+  box-shadow:
+    0 0 0 1px rgba(59, 58, 58, 0.22),
+    0 0 10px rgba(244, 240, 232, 0.24);
+  pointer-events: none;
+  opacity: 0;
+  transform: translate3d(-100px, -100px, 0);
+  transition: opacity 0.16s ease;
+  will-change: transform;
+}
+
+html.using-custom-cursor,
+html.using-custom-cursor body,
+html.using-custom-cursor *,
+html.using-custom-cursor *::before,
+html.using-custom-cursor *::after {
+  cursor: none !important;
+}
+
+html.using-custom-cursor #custom-cursor {
+  opacity: 1;
 }
 
 @media (max-width: 720px) {


### PR DESCRIPTION
so, it is actually really very hard to make the native cursor disappear.

Chrome/macOS can leak or restore the native arrow cursor even when applying `cursor: none`, especially around the about interaction or after moving up into the browser. CSS-only hiding and custom cursor URL fallbacks aren't reliable enough.

# What changed

- Cursor handling now uses Pointer Lock on the full-screen cursor hit layer instead of relying only on CSS cursor suppression.
- A DOM cursor ring is rendered as the visible cursor, while locked mouse movement is tracked with `movementX`/`movementY` and applied to a virtual cursor position.
- The about interaction is routed through coordinate hit-testing against that virtual cursor, so opening/closing the modal does not depend on native hover/click targeting.
- Follow-up mouse/click events from the same gesture are suppressed so the about modal does not immediately toggle back closed.
- Early inline CSS in `index.html` hides the native cursor before the bundled CSS/JS load, with the stylesheet keeping `cursor: none !important` as the fallback.

Known browser behavior: Chrome owns the Pointer Lock escape hint and does not expose a page-level way to disable it.

The escape hint is kind of annoying and sad, but seems necessary.